### PR TITLE
Remoção do SNAPSHOT da versão

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>mtfn</groupId>
 	<artifactId>mtfn</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2</version>
 	<packaging>jar</packaging>
 	<name>mtfn</name>
 	<url>http://maven.apache.org</url>


### PR DESCRIPTION
Olá, 

De acordo com esse site: http://datasift.github.io/gitflow/Versioning.html, as versões de snaphot não devem ficar no branch de produção, apenas nos branchs de desenvolvimento.

```
Snapshot versions should only be installed on dev boxes and integration 
environments. They shouldn’t be deployed to any of the dedicated 
test environments.
```

Por isso o pull request.

[ ]s
Leandro.
